### PR TITLE
Backfill testing for extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+base_job: &base_job
+  working_directory: ~/middleman-prismic
+  steps:
+    - checkout
+    - run:
+        name: Setup environment
+        command: ./bin/setup
+    - run:
+        name: Run tests
+        command: bundle exec rake
+
+jobs:
+  ruby2.3:
+    <<: *base_job
+    docker:
+      - image: circleci/ruby:2.3-node
+  ruby2.4:
+    <<: *base_job
+    docker:
+      - image: circleci/ruby:2.4-node
+  ruby2.5:
+    <<: *base_job
+    docker:
+      - image: circleci/ruby:2.5-node
+
+workflows:
+  version: 2
+  ruby-versions:
+    jobs:
+      - ruby2.3
+      - ruby2.4
+      - ruby2.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.gem
 /.bundle/
 /.yardoc
 /Gemfile.lock
@@ -8,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.gem
 /.bundle/
 /.yardoc
 /Gemfile.lock
@@ -7,4 +8,3 @@
 /pkg/
 /spec/reports/
 /tmp/
-*.gem

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format documentation
+--format progress
 --color

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,14 @@
-# If you do not have OpenSSL installed, update
-# the following line to use "http://" instead
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-# Specify your gem's dependencies in test-extension.gemspec
 gemspec
 
 group :development do
-  gem 'rake'
-  gem 'rdoc'
-  gem 'yard'
+  gem "rake"
+  gem "rdoc"
+  gem "yard"
+  gem "middleman"
 end
 
 group :test do
-  gem 'rspec'
+  gem "rspec"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,14 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "middleman"
   gem "rake"
   gem "rdoc"
   gem "yard"
-  gem "middleman"
 end
 
 group :test do
+  gem "capybara_discoball"
   gem "rspec"
+  gem "sinatra"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,8 @@
-require "bundler/gem_tasks"
+require "bundler"
+require "rspec/core/rake_task"
+require "rake/clean"
 
+Bundler::GemHelper.install_tasks
+
+task default: :spec
+RSpec::Core::RakeTask.new

--- a/lib/middleman-prismic.rb
+++ b/lib/middleman-prismic.rb
@@ -1,7 +1,7 @@
-require 'prismic'
-require 'middleman-core'
-require 'middleman-prismic/version'
-require 'middleman-prismic/commands/prismic'
+require "prismic"
+require "middleman-core"
+require "middleman-prismic/version"
+require "middleman-prismic/commands/prismic"
 
 module Middleman
   module Prismic

--- a/middleman-prismic.gemspec
+++ b/middleman-prismic.gemspec
@@ -1,24 +1,24 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'middleman-prismic/version'
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require "middleman-prismic/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "middleman-prismic"
-  spec.version       = MiddlemanPrismic::VERSION
-  spec.authors       = ["Filippos Vasilakis"]
-  spec.email         = ["vasilakisfil@gmail.com"]
+  spec.name = "middleman-prismic"
+  spec.version = MiddlemanPrismic::VERSION
+  spec.platform = Gem::Platform::RUBY
+  spec.authors = ["Filippos Vasilakis"]
+  spec.email = ["vasilakisfil@gmail.com"]
 
   spec.summary       = %q{Middleman extension for Prismic}
   spec.description   = %q{Middleman extension for Prismic}
   spec.homepage      = "https://github.com/kollegorna/middleman-prismic"
   spec.license       = "MIT"
-
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = `git ls-files`.split("\n")
+  spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "middleman-cli", "~> 4.2"
-  spec.add_runtime_dependency "middleman-core", "~> 4.2"
+  spec.add_runtime_dependency "middleman-core", ">= 4.2.1"
+  spec.add_runtime_dependency "middleman-cli", ">= 4.2.1"
   spec.add_runtime_dependency "prismic.io", "~> 1.6"
 end

--- a/spec/fixtures/responses/root.json.erb
+++ b/spec/fixtures/responses/root.json.erb
@@ -1,0 +1,122 @@
+{
+  "refs": [
+    {
+      "id": "master",
+      "ref": "MasterRef",
+      "label": "Master",
+      "isMasterRef": true
+    }
+  ],
+  "bookmarks": {
+  },
+  "types": {
+    "demo-result": "Demo Result"
+  },
+  "tags": [],
+  "forms": {
+    "demo-result": {
+      "name": "Demo Result",
+      "method": "GET",
+      "rel": "collection",
+      "enctype": "application/x-www-form-urlencoded",
+      "action": "<%= uri('documents/search') %>",
+      "fields": {
+        "ref": {
+          "type": "String",
+          "multiple": false
+        },
+        "q": {
+          "default": "[[:d = any(document.type, [\"demo-result\"])]]",
+          "type": "String",
+          "multiple": true
+        },
+        "lang": {
+          "type": "String",
+          "multiple": false
+        },
+        "page": {
+          "type": "Integer",
+          "multiple": false,
+          "default": "1"
+        },
+        "pageSize": {
+          "type": "Integer",
+          "multiple": false,
+          "default": "20"
+        },
+        "after": {
+          "type": "String",
+          "multiple": false
+        },
+        "fetch": {
+          "type": "String",
+          "multiple": false
+        },
+        "fetchLinks": {
+          "type": "String",
+          "multiple": false
+        },
+        "orderings": {
+          "type": "String",
+          "multiple": false
+        },
+        "referer": {
+          "type": "String",
+          "multiple": false
+        }
+      }
+    },
+    "everything": {
+      "method": "GET",
+      "enctype": "application/x-www-form-urlencoded",
+      "action": "<%= uri('documents/search') %>",
+      "fields": {
+        "ref": {
+          "type": "String",
+          "multiple": false
+        },
+        "q": {
+          "type": "String",
+          "multiple": true
+        },
+        "lang": {
+          "type": "String",
+          "multiple": false
+        },
+        "page": {
+          "type": "Integer",
+          "multiple": false,
+          "default": "1"
+        },
+        "pageSize": {
+          "type": "Integer",
+          "multiple": false,
+          "default": "20"
+        },
+        "after": {
+          "type": "String",
+          "multiple": false
+        },
+        "fetch": {
+          "type": "String",
+          "multiple": false
+        },
+        "fetchLinks": {
+          "type": "String",
+          "multiple": false
+        },
+        "orderings": {
+          "type": "String",
+          "multiple": false
+        },
+        "referer": {
+          "type": "String",
+          "multiple": false
+        }
+      }
+    }
+  },
+  "oauth_initiate": "<%= uri('/auth') %>",
+  "oauth_token": "<%= uri('/auth/token') %>",
+  "version": "version"
+}

--- a/spec/fixtures/responses/search.json.erb
+++ b/spec/fixtures/responses/search.json.erb
@@ -1,0 +1,61 @@
+{
+  "page": 1,
+  "results_per_page": 20,
+  "results_size": 1,
+  "total_results_size": 1,
+  "total_pages": 1,
+  "next_page": null,
+  "prev_page": null,
+  "results": [
+    {
+      "id": "<%= document.id %>",
+      "uid": "<%= document.type %>",
+      "type": "<%= document.type %>",
+      "href": "<%= uri('/documents/search?ref=refref') %>",
+      "tags": [],
+      "first_publication_date": "2018-04-09T17:21:43+0000",
+      "last_publication_date": "2018-04-09T17:21:43+0000",
+      "slugs": [
+        "demo-test"
+      ],
+      "linked_documents": [],
+      "lang": "en-us",
+      "alternate_languages": [],
+      "data": {
+        "press_release": {
+          "date": {
+            "type": "Date",
+            "value": "2015-01-14"
+          },
+          "title": {
+            "type": "StructuredText",
+            "value": [
+              {
+                "type": "heading1",
+                "text": "A very good test heading",
+                "spans": []
+              }
+            ]
+          },
+          "body": {
+            "type": "StructuredText",
+            "value": [
+              {
+                "type": "paragraph",
+                "text": "A paragraph with some very strong text",
+                "spans": [
+                  {
+                    "start": 0,
+                    "end": 29,
+                    "type": "strong"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "version": "version"
+}

--- a/spec/middleman-prismic/commands/prismic_spec.rb
+++ b/spec/middleman-prismic/commands/prismic_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+describe Middleman::Cli::Prismic do
+  describe "#prismic", :in_temp_directory do
+    it "creates the directory that prismic data should live in" do
+      stub_options
+      stub_prismic_api
+
+      expect(File).not_to exist(described_class::DATA_DIR)
+
+      described_class.new.prismic
+
+      expect(File).to exist(described_class::DATA_DIR)
+    end
+
+    it "collects all paginated documents and writes them to file" do
+      stub_options
+      document = double("document", id: "thing", to_yaml: "yaml")
+      response = double(
+        "response",
+        group_by: { "foo" => [document] },
+        total_pages: 1,
+      )
+      stub_prismic_api(response)
+
+      described_class.new.prismic
+
+      file_path = File.join(described_class::DATA_DIR, "foos")
+
+      expect(File).to exist(file_path)
+      expect(Dir.entries(file_path) - [".", ".."]).
+        to eq ["#{Digest::MD5.hexdigest(document.id)}.yml"]
+    end
+
+    it "outputs all references" do
+      stub_options
+      stub_prismic_api
+      reference_path = File.join(described_class::DATA_DIR, "reference.yml")
+
+      expect(File).not_to exist(reference_path)
+
+      described_class.new.prismic
+
+      expect(File).to exist(reference_path)
+    end
+
+    it "outputs any custom queries" do
+      prismic_query = double("prismic_query")
+      stub_options(
+        custom_queries: {
+          test: [prismic_query]
+        }
+      )
+      document = double("document", id: "thing", to_yaml: "yaml")
+      response = double(
+        "response",
+        group_by: { "foo" => [document] },
+        each: [document],
+        total_pages: 1,
+      )
+      api_form = stub_prismic_api(response)
+      allow(api_form).to receive(:query).and_return(api_form)
+
+      custom_path = File.join(described_class::DATA_DIR, "custom_test")
+      expect(File).not_to exist(custom_path)
+
+      described_class.new.prismic
+
+      expect(File).to exist(custom_path)
+      expect(api_form).
+        to have_received(:query).
+          with(prismic_query)
+    end
+  end
+
+  def stub_options(hash = {})
+    options = double(
+      "options",
+      {
+        access_token: nil,
+        api_url: "http://example.com",
+        release: "release",
+        custom_queries: [],
+      }.merge(hash)
+    )
+    allow(Middleman::Prismic).to receive(:options).and_return(options)
+  end
+
+  def stub_prismic_api(response = double("response", group_by: [], total_pages: 1))
+    api_form = double("api_form", page: double, submit: response)
+    api = double("api", form: api_form, ref: double, master_ref: "ref")
+    allow(Prismic).to receive(:api).and_return(api)
+    api_form
+  end
+end

--- a/spec/middleman_prismic_spec.rb
+++ b/spec/middleman_prismic_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe MiddlemanPrismic do
   it 'has a version number' do

--- a/spec/middleman_prismic_spec.rb
+++ b/spec/middleman_prismic_spec.rb
@@ -1,11 +1,34 @@
 require "spec_helper"
 
 describe MiddlemanPrismic do
-  it 'has a version number' do
-    expect(MiddlemanPrismic::VERSION).not_to be nil
+  describe "download from prismic", :in_temp_directory do
+    it "downloads content from prismic and installs in directory" do |example|
+      Capybara::Discoball.spin(FakePrismic) do |server|
+        directory = example.metadata[:directory]
+        FakePrismic.set_document(id: "referoo", type: "demo-test")
+        change_directory_and_configure_with_prismic(directory, server)
+
+        run_middleman_prismic
+
+        hex_string = Digest::MD5.hexdigest("referoo")
+        document = YAML.load_file("data/prismic/demo-tests/#{hex_string}.yml")
+
+        expect(document.id).to eq "referoo"
+      end
+    end
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  def change_directory_and_configure_with_prismic(directory, server)
+    File.open("config.rb", "w") do |file|
+      file.write <<~RUBY
+        activate :prismic do |f|
+          f.api_url = "#{server.url}"
+        end
+      RUBY
+    end
+  end
+
+  def run_middleman_prismic
+    `middleman prismic`
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,10 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require "bundler/setup"
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "middleman-prismic"
+Dir.glob(File.expand_path("../support/*.rb", __FILE__)).each { |f| require f }
+
+RSpec.configure do |config|
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+  config.order = "random"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'middleman-prismic'
+require "middleman-prismic"

--- a/spec/support/fake_prismic.rb
+++ b/spec/support/fake_prismic.rb
@@ -1,0 +1,32 @@
+require "sinatra/base"
+require "capybara_discoball"
+require "json"
+require "ostruct"
+
+class FakePrismic < Sinatra::Base
+  set :views, Proc.new { File.expand_path("../../fixtures/responses/", __FILE__) }
+
+  @@document = nil
+
+  def self.set_document(id:, type:)
+    @@document = OpenStruct.new(id: id, type: type)
+  end
+
+  def self.reset
+    @@document = nil
+  end
+
+  get "/" do
+    erb "root.json".to_sym
+  end
+
+  get "/documents/search" do
+    erb "search.json".to_sym, locals: { document: @@document }
+  end
+end
+
+RSpec.configure do |config|
+  config.after(:each, type: :feature) do
+    FakePrismic.reset
+  end
+end

--- a/spec/support/temporary_directory.rb
+++ b/spec/support/temporary_directory.rb
@@ -1,0 +1,21 @@
+require "tmpdir"
+
+class TemporaryDirectory
+  def create_and_move_to_temporary_directory
+    Dir.mktmpdir do |directory|
+      Dir.chdir(directory) do
+        yield(directory)
+      end
+    end
+  end
+end
+
+
+RSpec.configure do |config|
+  config.around(in_temp_directory: true) do |example|
+    TemporaryDirectory.new.create_and_move_to_temporary_directory do |directory|
+      example.metadata[:directory] = directory
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
Taking advantage of a fake server to stub out the prismic api and provide
the most simple use case for it to do what it is intended to do, download
information from prismic and make it available to middleman

* Define integration happy path for prismic gem
* Use capybara_discoball and sinatra to stub out prismic
* Provide fake but realistic output from api
* Do everything in a temporary folder
* Add some basic unit tests
* Install prismic extension from command line