### PR TITLE
Pass reference for content outside master release

### DIFF
--- a/lib/middleman-prismic/commands/prismic.rb
+++ b/lib/middleman-prismic/commands/prismic.rb
@@ -9,6 +9,12 @@ module Middleman
       # Path where Middleman expects the local data to be stored
       DATA_DIR = 'data/prismic'.freeze
 
+      class_option(
+        :ref,
+        type: :string,
+        desc: "Pull content from Prismic by ref instead of configured release",
+      )
+
       check_unknown_options!
 
       namespace :prismic
@@ -82,7 +88,7 @@ module Middleman
       end
 
       def api_reference
-        api.ref(Middleman::Prismic.options.release)
+        options[:ref] || api.ref(Middleman::Prismic.options.release)
       end
 
       def api

--- a/spec/middleman-prismic/commands/prismic_spec.rb
+++ b/spec/middleman-prismic/commands/prismic_spec.rb
@@ -71,6 +71,18 @@ describe Middleman::Cli::Prismic do
         to have_received(:query).
           with(prismic_query)
     end
+
+    it "downloads via prismic ref" do
+      stub_options
+      response = double("response", group_by: [], total_pages: 1)
+      reference = "reference"
+      api_form = stub_prismic_api(response)
+      allow(api_form).to receive(:submit).and_return(response)
+
+      described_class.new([], ref: reference).prismic
+
+      expect(api_form).to have_received(:submit).with(reference)
+    end
   end
 
   def stub_options(hash = {})

--- a/spec/support/fake_prismic.rb
+++ b/spec/support/fake_prismic.rb
@@ -4,12 +4,14 @@ require "json"
 require "ostruct"
 
 class FakePrismic < Sinatra::Base
+  MASTER_REF = "MasterRef"
+
   set :views, Proc.new { File.expand_path("../../fixtures/responses/", __FILE__) }
 
   @@document = nil
 
-  def self.set_document(id:, type:)
-    @@document = OpenStruct.new(id: id, type: type)
+  def self.set_document(id:, type:, ref: MASTER_REF)
+    @@document = OpenStruct.new(id: id, type: type, ref: ref)
   end
 
   def self.reset
@@ -21,7 +23,9 @@ class FakePrismic < Sinatra::Base
   end
 
   get "/documents/search" do
-    erb "search.json".to_sym, locals: { document: @@document }
+    if @@document.ref == params["ref"]
+      erb "search.json".to_sym, locals: { document: @@document }
+    end
   end
 end
 


### PR DESCRIPTION
Rather than explicitly working off of a release as the extension is
set to do, it would be nice to pass along a reference so that we can
get content in a mode ad-hoc fashion.

This is needed in order to implement preview like functionality into
something like middleman.

* Provide `--ref` to commandline interface