### PR TITLE
Add Middleman::Prismic::Preview middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install middleman-prismic
-i
+
 ## Configuration
 
 To configure the extension, add the following configuration block to Middleman's config.rb:
@@ -54,9 +54,32 @@ For instance for articles, if you run `<%= articles %>` you get back a `Prismic:
 
 If at any time need access to `Prismic::Ref` you can do it using the `reference` helper.
 
+## Prismic Preview
+
+Prismic supports a preview function by sending a browser to `/preview`
+with a `token` and `document_id` on the query. This middleware is intended
+to hook into Middleman to add a `/preview` endpoint that will fetch the
+preview content by token (as `ref`) and display the content in the Middleman
+server.
+
+In your Middleman app, add the following to `config.rb` to activate
+this middleware:
+
+```ruby
+require "middleman-prismic/preview"
+
+use Middleman::Prismic::Preview
+```
+
+Now when running the `middleman` server, any requests to `/preview` will be
+intercepted. The `token` param will be read and used to execute
+`middleman prismic --ref ${token}`. Because Middleman is running as a
+server, when the content from Prismic is downloaded, it will show the
+live content when browsing the Middleman site.
+
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment. 
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/middleman-prismic/preview.rb
+++ b/lib/middleman-prismic/preview.rb
@@ -1,0 +1,25 @@
+module Middleman
+  module Prismic
+    class Preview
+      def initialize(app, options={})
+        @app = app
+      end
+
+      def call(env)
+        req = ::Rack::Request.new(env)
+        if req.path =~ %r(^/preview)
+          token = req.params["token"]
+
+          succeeded = Kernel.system "middleman", "prismic", "--ref", token
+          if succeeded
+            [302, {'Location' => '/'}, ['Found']]
+          else
+            [500, {'Location' => '/?error=preview_failure'}, ['Error']]
+          end
+        else
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/spec/middleman-prismic/preview_spec.rb
+++ b/spec/middleman-prismic/preview_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+require "middleman-prismic/preview"
+
+describe Middleman::Prismic::Preview do
+  it "passes through requests outside of /preview" do
+    stub_system
+    expected_response = double(:expected_response)
+    app = rack_app(response: expected_response)
+    request = env_for("http://example.com/")
+
+    middleware = Middleman::Prismic::Preview.new(app)
+    response = middleware.call request
+
+    expect(Kernel).not_to have_received(:system)
+    expect(app).to have_received(:call).with(request)
+    expect(response).to be expected_response
+  end
+
+  context "given a request to /preview" do
+    it "intercepts the request" do
+      stub_system
+      app = rack_app
+      request = env_for("http://example.com/preview")
+
+      middleware = Middleman::Prismic::Preview.new(app)
+      code, headers, message = middleware.call request
+
+      expect(code).to eq 302
+      expect(message).to respond_to(:each)
+    end
+
+    it "fetches the prismic content for the ref" do
+      stub_system
+      app = rack_app
+      request = env_for("http://example.com/preview?token=foo%20bar%20token")
+
+      middleware = Middleman::Prismic::Preview.new(app)
+      code, headers, message = middleware.call request
+
+      expect(Kernel).to have_received(:system).
+        with("middleman", "prismic", "--ref", "foo bar token")
+      expect(message).to respond_to(:each)
+    end
+
+    context "when the request fails" do
+      it "returns a 500" do
+        stub_system(exit_status: false)
+        app = rack_app
+        request = env_for("http://example.com/preview")
+
+        middleware = Middleman::Prismic::Preview.new(app)
+        code, headers, message = middleware.call request
+
+        expect(code).to eq 500
+      end
+    end
+  end
+
+  private
+
+  def rack_app(response: [200, {"Content-Type" => "text/plain"}, ["OK"]])
+    spy(:rack_app, call: response)
+  end
+
+  def env_for(url)
+    Rack::MockRequest.env_for(url)
+  end
+
+  def stub_system(exit_status: true)
+    allow(Kernel).to receive(:system).and_return(exit_status)
+  end
+end


### PR DESCRIPTION
Prismic supports a preview function by sending a browser to /preview
with a token and document_id on the query. This middleware is intended
to hook into Middleman to add a /preview endpoint that will fetch the
preview content by token and display the content in the Middleman
server.

In your Middleman app, add the following to `config.rb` to activate
this middleware:

```ruby
require "middleman-prismic/preview"

use Middleman::Prismic::Preview
```

Now when you run `middleman`, any requests to `/preview` will be
intercepted. The `token` param will be read and used to execute
`middleman prismic --ref ${token}`. Because Middleman is running as a
server, when the content from Prismic is downloaded, it will show the
live content when browsing the Middleman site.

Next piece of work will be to support `document_id` by allowing a
Prismic Link Resolver into the middleware when called `use`.