### PR TITLE
Add support for link_resolver for preview redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ this middleware:
 ```ruby
 require "middleman-prismic/preview"
 
-use Middleman::Prismic::Preview
+use Middleman::Prismic::Preview,
+  app_url: 'https://mysite.prismic.io/api',
+  link_resolver: link_resolver
 ```
 
 Now when running the `middleman` server, any requests to `/preview` will be

--- a/lib/middleman-prismic.rb
+++ b/lib/middleman-prismic.rb
@@ -13,11 +13,7 @@ module Middleman
       option :api_url, nil, 'The Prismic API URL'
       option :release, 'master', 'Content release'
       option :access_token, nil, 'Access token (optional)'
-      option(
-        :link_resolver,
-        ->(link) {"http://www.example.com/#{link.type.pluralize}/#{link.slug}"},
-        'The link resolver'
-      )
+      option :link_resolver, ->(_link) {"/"}, 'The link resolver'
       option :custom_queries, {}, 'Custom queries'
 
       def initialize(app, options_hash={}, &block)

--- a/lib/middleman-prismic/preview.rb
+++ b/lib/middleman-prismic/preview.rb
@@ -3,6 +3,7 @@ module Middleman
     class Preview
       def initialize(app, options={})
         @app = app
+        @options = options
       end
 
       def call(env)
@@ -10,14 +11,23 @@ module Middleman
         if req.path =~ %r(^/preview)
           token = req.params["token"]
 
-          succeeded = Kernel.system "middleman", "prismic", "--ref", token
+          succeeded = Kernel.system 'middleman', 'prismic', '--ref', token
           if succeeded
-            [302, {'Location' => '/'}, ['Found']]
+            [302, {'Location' => preview_url(token)}, ['Found']]
           else
             [500, {'Location' => '/?error=preview_failure'}, ['Error']]
           end
         else
           @app.call(env)
+        end
+      end
+
+      def preview_url(token)
+        if @options[:api_url] && @options[:link_resolver]
+          api = ::Prismic.api(@options[:api_url])
+          api.preview_session(token, @options[:link_resolver], '/')
+        else
+          '/'
         end
       end
     end


### PR DESCRIPTION
Add support to passing in an `api_url` and `link_resolver` to the Preview middleware. When these are passed, it becomes possible for the preview to redirect the browser directly to the previewed content instead of just to the homepage.