### PR TITLE
Improve error handling and reporting

### DIFF
--- a/lib/middleman-prismic/preview.rb
+++ b/lib/middleman-prismic/preview.rb
@@ -14,17 +14,17 @@ module Middleman
           token = req.params["token"]
 
           begin
-            stdout_and_stderr, status = Open3.capture2e('middleman', 'prismic', '--ref', token)
+            stdout_and_stderr, status = Open3.capture2e("middleman", "prismic", "--ref", token)
 
             if status.success?
-              [302, {'Location' => preview_url(token)}, ['Found']]
+              [302, {"Location" => preview_url(token)}, ["Found"]]
             else
-              [500, {'Location' => '/?error=preview_failure'}, [stdout_and_stderr]]
+              [500, {"Location" => "/?error=preview_failure"}, [stdout_and_stderr]]
             end
           rescue Exception => e
             [
               500,
-              {'Location' => '/?error=preview_failue'},
+              {"Location" => "/?error=preview_failue"},
               [e.message, "\n\t#{e.backtrace.join("\n\t")}" ]
             ]
           end
@@ -36,9 +36,9 @@ module Middleman
       def preview_url(token)
         if @options[:api_url] && @options[:link_resolver]
           api = ::Prismic.api(@options[:api_url])
-          api.preview_session(token, @options[:link_resolver], '/')
+          api.preview_session(token, @options[:link_resolver], "/")
         else
-          '/'
+          "/"
         end
       end
     end

--- a/spec/middleman-prismic/preview_spec.rb
+++ b/spec/middleman-prismic/preview_spec.rb
@@ -47,9 +47,9 @@ describe Middleman::Prismic::Preview do
       stub_system
       app = rack_app
       request = env_for("http://example.com/preview?token=foo%20bar%20token")
-      api_url = 'http://prismic.url'
+      api_url = "http://prismic.url"
       link_resolver = double(:link_resolver)
-      prismic_spy = spy(Prismic, preview_session: '/foobar')
+      prismic_spy = spy(Prismic, preview_session: "/foobar")
       allow(Prismic).to receive(:api) { prismic_spy }
 
       middleware = Middleman::Prismic::Preview.new(
@@ -62,7 +62,7 @@ describe Middleman::Prismic::Preview do
       expect(Prismic).to have_received(:api).with(api_url)
       expect(prismic_spy).to have_received(:preview_session)
       expect(code).to eq 302
-      expect(headers).to include 'Location' => '/foobar'
+      expect(headers).to include "Location" => "/foobar"
     end
 
     context "when the request fails" do


### PR DESCRIPTION
- Switch from `Kernel#system` to `Open3#capture3` which allows capturing `stdout` and `stderr`
- Rescue from an `Error` thrown by `#preview_url` and report on that error